### PR TITLE
validHash always returning true for no reqs (cuz [] is truthy)

### DIFF
--- a/chrome/app.js
+++ b/chrome/app.js
@@ -792,7 +792,7 @@ Gmail2Trello.App.prototype.validHash = function (args, reqs = []) {
         return false;
     }
 
-    var fields = reqs || Object.keys(args),
+    var fields = reqs && reqs.length ? reqs : Object.keys(args),
         field1,
         valid = true;
 

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Gmail-2-Trello",
   "short_name": "G2T",
-  "version": "2.8.0.012",
+  "version": "2.8.0.013",
   "manifest_version": 2,
   "description": "Gmail+Trello integration. Was \"Gmail-to-Trello\". Create new Trello cards from Google mail with backlinks and attachments.",
   "icons": {

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -1,3 +1,6 @@
+=== 2.8.0.013@2020-05-22 ===
+ * Fix validHash to work correctly - was always taking the req = [] path. This was causing empty data to be sent to Trello, causing a 400 error
+
 === 2.8.0.012@2020-05-15 ===
  * Update icons for correct classes for Gmail with highlighting css
 


### PR DESCRIPTION
Fix validHash to work correctly - was always taking the req = [] path. This was causing empty data to be sent to Trello, causing a 400 error
