### PR TITLE
2.8.5.001: Restore settings based on emails!

### DIFF
--- a/chrome/app.js
+++ b/chrome/app.js
@@ -7,9 +7,9 @@ Gmail2Trello.App = function () {
     this.CHROME_SETTINGS_ID = "g2t_user_settings";
     this.UNIQUE_URI_VAR = "g2t_filename";
 
-    this.popupView = new Gmail2Trello.PopupView(this);
-    this.gmailView = new Gmail2Trello.GmailView(this);
     this.model = new Gmail2Trello.Model(this);
+    this.gmailView = new Gmail2Trello.GmailView(this);
+    this.popupView = new Gmail2Trello.PopupView(this);
 
     this.bindEvents();
 };
@@ -679,16 +679,14 @@ Gmail2Trello.App.prototype.loadSettings = function (popup) {
     chrome.storage.sync.get(setID, function (response) {
         if (response && response.hasOwnProperty(setID)) {
             // NOTE (Ace, 7-Feb-2017): Might need to store these off the app object:
-            let settings_parsed = {};
             try {
-                settings_parsed = JSON.parse(response[setID]);
+                self.popupView.data.settings = JSON.parse(response[setID]);
             } catch (err) {
                 g2t_log(
                     "loadSettings: JSON parse failed! Error: " +
                         JSON.stringify(err)
                 );
             }
-            self.popupView.data.settings = settings_parsed;
         }
         if (popup) {
             popup.init_popup();

--- a/chrome/content-script.js
+++ b/chrome/content-script.js
@@ -25,7 +25,7 @@ function g2t_log(data) {
         window.g2t_log_g = {
             memory: [],
             count: 0,
-            max: 300,
+            max: 100,
             debugMode: false,
         };
         chrome.storage.sync.get("debugMode", function (response) {

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Gmail-2-Trello",
   "short_name": "G2T",
-  "version": "2.8.0.014",
+  "version": "2.8.5.001",
   "manifest_version": 2,
   "description": "Gmail+Trello integration. Was \"Gmail-to-Trello\". Create new Trello cards from Google mail with backlinks and attachments.",
   "icons": {

--- a/chrome/views/popupView.html
+++ b/chrome/views/popupView.html
@@ -34,9 +34,6 @@
   <div class="popupMsg">Loading...</div>
   <div class="content" style="display: none;">
     <div class="g2tTopRight">
-      <div style="float: left;" class="clearfix listrow">
-        <!-- <ul id="g2tPosition" /> -->
-      </div>
       <div style="float: right;">
         <input
           type="button"

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -1,6 +1,8 @@
 === 2.8.1.001@2020-05-22 ===
  * First cut at remembering what message was stored with what card
  * Move to safer "g2t_" instead of "g2t:" for variable names stored in hashes
+ * Reduce log lines circular queue to 100 lines
+ * Set "remembered" to 100 emails
 
 === 2.8.0.013@2020-05-22 ===
  * Fix validHash to work correctly - was always taking the req = [] path. This was causing empty data to be sent to Trello, causing a 400 error


### PR DESCRIPTION
 * First cut at remembering what message was stored with what card
 * Move to safer "g2t_" instead of "g2t:" for variable names stored in hashes
 * Reduce log lines circular queue to 100 lines
 * Set "remembered" to 100 emails
 * First version of restoring settings based on email, had to add ability to cache list updates til list refreshed