### PR TITLE
Manifest updates for api-gateway error, allow '--' to always clear due date

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -69,12 +69,12 @@
     "browsingData",
     "tabs",
     "storage",
-    "https://api.trello.com/",
-    "https://trello.com/",
+    "https://*.trello.com/",
     "https://mail.google.com/",
-    "https://www.googleapis.com/",
-    "https://www.google-analytics.com/",
-    "https://*.googleusercontent.com/"
+    "https://*.googleapis.com/",
+    "https://*.google-analytics.com/",
+    "https://*.googleusercontent.com/",
+    "https://*.gstatic.com/"
   ],
   "options_page": "views/options.html",
   "oauth2": {

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -1,7 +1,7 @@
 === 2.8.5.008@2020-07-18 ===
  * Make due shortcuts reset when picking "--" even when it's selected
- * Change manifest to *.trello.com to support api.trello.com, api-gateway.trello.com
- * Add *.gstatic.com to manifest for googleusercontent
+ * Change manifest to '*.trello.com' to support api.trello.com, api-gateway.trello.com
+ * Add '*.gstatic.com' to manifest for googleusercontent
 
 === 2.8.5.007@2020-07-15 ===
  * @KS-CleverCopter fix for images hover clipping, Where: a few pixels misaligned

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -1,5 +1,7 @@
-=== 2.8.5.008@2020-07-16 ===
+=== 2.8.5.008@2020-07-18 ===
  * Make due shortcuts reset when picking "--" even when it's selected
+ * Change manifest to *.trello.com to support api.trello.com, api-gateway.trello.com
+ * Add *.gstatic.com to manifest for googleusercontent
 
 === 2.8.5.007@2020-07-15 ===
  * @KS-CleverCopter fix for images hover clipping, Where: a few pixels misaligned


### PR DESCRIPTION
=== 2.8.5.008@2020-07-18 ===
 * Make due shortcuts reset when picking "--" even when it's selected
 * Change manifest to *.trello.com to support api.trello.com, api-gateway.trello.com
 * Add *.gstatic.com to manifest for googleusercontent