### PR TITLE
Fix g2t disappearing on view change

### DIFF
--- a/chrome_manifest_v3/class_app.js
+++ b/chrome_manifest_v3/class_app.js
@@ -13,6 +13,11 @@ class App {
     return ck;
   }
 
+  // Extract the Gmail nav selectors into a single constant for easier maintenance
+  static get GMAIL_NAV_SELECTORS() {
+    return '[role="navigation"], .bq9, .bqA, .bqB, .bqC, .bqD, .bqE, .bqF, .bqG, .bqH, .bqI, .bqJ, .bqK, .bqL, .bqM, .bqN, .bqO, .bqP, .bqQ, .bqR, .bqS, .bqT, .bqU, .bqV, .bqW, .bqX, .bqY, .bqZ, [data-tooltip*="Inbox"], [data-tooltip*="Starred"], [data-tooltip*="Sent"], [data-tooltip*="Drafts"], [data-tooltip*="Spam"], [data-tooltip*="Trash"], [aria-label*="Inbox"], [aria-label*="Starred"], [aria-label*="Sent"], [aria-label*="Drafts"], [aria-label*="Spam"], [aria-label*="Trash"]';
+  }
+
   get ck() {
     return App.ck;
   }
@@ -105,7 +110,7 @@ class App {
     document.addEventListener('click', (event) => {
       // Check if the click is on a Gmail navigation element
       const $target = $(event.target);
-      const isGmailNav = $target.closest('[role="navigation"], .bq9, .bqA, .bqB, .bqC, .bqD, .bqE, .bqF, .bqG, .bqH, .bqI, .bqJ, .bqK, .bqL, .bqM, .bqN, .bqO, .bqP, .bqQ, .bqR, .bqS, .bqT, .bqU, .bqV, .bqW, .bqX, .bqY, .bqZ, [data-tooltip*="Inbox"], [data-tooltip*="Starred"], [data-tooltip*="Sent"], [data-tooltip*="Drafts"], [data-tooltip*="Spam"], [data-tooltip*="Trash"], [aria-label*="Inbox"], [aria-label*="Starred"], [aria-label*="Sent"], [aria-label*="Drafts"], [aria-label*="Spam"], [aria-label*="Trash"]').length > 0;
+      const isGmailNav = $target.closest(App.GMAIL_NAV_SELECTORS).length > 0;
       
       if (isGmailNav) {
         // Add a small delay to allow Gmail to complete the navigation
@@ -120,13 +125,13 @@ class App {
     const originalPushState = history.pushState;
     const originalReplaceState = history.replaceState;
     
+    const app = this;
+    
     history.pushState = function(...args) {
       originalPushState.apply(history, args);
       // Trigger navigation detection after a short delay
       setTimeout(() => {
-        if (window.g2t_app) {
-          window.g2t_app.handleGmailNavigation();
-        }
+        app.handleGmailNavigation();
       }, 50);
     };
     
@@ -134,9 +139,7 @@ class App {
       originalReplaceState.apply(history, args);
       // Trigger navigation detection after a short delay
       setTimeout(() => {
-        if (window.g2t_app) {
-          window.g2t_app.handleGmailNavigation();
-        }
+        app.handleGmailNavigation();
       }, 50);
     };
 

--- a/chrome_manifest_v3/views/class_gmailView.js
+++ b/chrome_manifest_v3/views/class_gmailView.js
@@ -310,6 +310,35 @@ class GmailView {
     }
   }
 
+  // Force a complete redraw of the G2T button
+  forceRedraw() {
+    g2t_log('GmailView:forceRedraw - forcing complete redraw');
+    
+    // Clear any existing button to force recreation
+    const $existingButton = $('#g2tButton');
+    if ($existingButton.length > 0) {
+      $existingButton.remove();
+    }
+    
+    // Clear any existing popup
+    const $existingPopup = $('#g2tPopup');
+    if ($existingPopup.length > 0) {
+      $existingPopup.remove();
+    }
+    
+    // Reset state
+    this.$toolBar = null;
+    this.runaway = 0;
+    
+    // Trigger popup view redraw as well
+    if (this.app.popupView && typeof this.app.popupView.handleForceRedraw === 'function') {
+      this.app.popupView.handleForceRedraw();
+    }
+    
+    // Trigger fresh detection
+    this.detect();
+  }
+
   detectToolbar() {
     // g2t_log('GmailView:detectToolbar');
 

--- a/chrome_manifest_v3/views/class_popupview.js
+++ b/chrome_manifest_v3/views/class_popupview.js
@@ -369,6 +369,12 @@ class PopupView {
       'classPopupViewInitDone',
       this.handlePopupViewInitDone.bind(this)
     );
+
+    // Bind force redraw event
+    this.app.events.addListener(
+      'forceRedraw',
+      this.handleForceRedraw.bind(this)
+    );
   }
 
   bindPopupEvents() {
@@ -1565,6 +1571,33 @@ class PopupView {
       this.$toolBar = this.app.gmailView.$toolBar;
       this.finalCreatePopup(); // Moved from init() to here
     }
+  }
+
+  // Handle forced redraw requests
+  handleForceRedraw() {
+    g2t_log('PopupView:handleForceRedraw - handling forced redraw request');
+    
+    // Clear any existing button and popup
+    const $existingButton = $('#g2tButton');
+    const $existingPopup = $('#g2tPopup');
+    
+    if ($existingButton.length > 0) {
+      $existingButton.remove();
+    }
+    
+    if ($existingPopup.length > 0) {
+      $existingPopup.remove();
+    }
+    
+    // Clear cached HTML
+    this.html = {};
+    
+    // Reset state
+    this.$toolBar = null;
+    this.isInitialized = false;
+    
+    // Trigger fresh detection
+    this.handleDetectButton();
   }
 
   handleBeforeAuthorize() {

--- a/chrome_manifest_v3/views/class_popupview.js
+++ b/chrome_manifest_v3/views/class_popupview.js
@@ -1939,10 +1939,7 @@ class PopupView {
     // inject a button & a popup
     // this.finalCreatePopup(); // Moved to handleDetectButton for now
 
-    // TEMPORARILY DISABLED (2024-12-19): Periodic button detection timer
-    // We're commenting out this section in hopes we won't need it anymore with the new navigation detection,
-    // but leaving it just in case the button disappears and we need the periodic check as a fallback.
-    // Uncomment the lines below if the button disappears and you need the periodic check
+    // NOTE (2025-07-18 @acoven): Keeping for now just commented out in case button randomly disappears
     /*
     if (this.intervalId) {
       clearInterval(this.intervalId);

--- a/chrome_manifest_v3/views/class_popupview.js
+++ b/chrome_manifest_v3/views/class_popupview.js
@@ -1939,7 +1939,9 @@ class PopupView {
     // inject a button & a popup
     // this.finalCreatePopup(); // Moved to handleDetectButton for now
 
-    // TEMPORARILY DISABLED: Periodic button detection timer
+    // TEMPORARILY DISABLED (2024-12-19): Periodic button detection timer
+    // We're commenting out this section in hopes we won't need it anymore with the new navigation detection,
+    // but leaving it just in case the button disappears and we need the periodic check as a fallback.
     // Uncomment the lines below if the button disappears and you need the periodic check
     /*
     if (this.intervalId) {

--- a/chrome_manifest_v3/views/class_popupview.js
+++ b/chrome_manifest_v3/views/class_popupview.js
@@ -1939,6 +1939,9 @@ class PopupView {
     // inject a button & a popup
     // this.finalCreatePopup(); // Moved to handleDetectButton for now
 
+    // TEMPORARILY DISABLED: Periodic button detection timer
+    // Uncomment the lines below if the button disappears and you need the periodic check
+    /*
     if (this.intervalId) {
       clearInterval(this.intervalId);
     }
@@ -1946,6 +1949,7 @@ class PopupView {
     this.intervalId = setInterval(() => {
       this.app.events.fire('detectButton');
     }, 2000);
+    */
 
     // Remove DOM-dependent code from here (was from init_popup)
 

--- a/docs/GMAIL_NAVIGATION_FIX.md
+++ b/docs/GMAIL_NAVIGATION_FIX.md
@@ -1,0 +1,143 @@
+# Gmail Navigation Fix for G2T Extension
+
+## Problem Description
+
+Users reported that the G2T (Gmail-2-Trello) extension initially loads correctly but "disappears" when they navigate between different Gmail views (e.g., from Inbox to Starred, Sent, Drafts, etc.). This happens because Gmail's interface dynamically updates the DOM structure when users switch views, and the extension's button detection wasn't robust enough to handle these navigation changes.
+
+## Root Cause Analysis
+
+1. **Gmail's Navigation System**: Gmail uses URL hash changes and internal routing to switch between views
+2. **DOM Structure Changes**: When users navigate, Gmail updates the main content area and toolbar structure
+3. **Button Attachment**: The G2T button gets attached to specific DOM elements that may be removed or replaced during navigation
+4. **Detection Timing**: The existing periodic detection (every 2 seconds) wasn't fast enough or reliable enough to catch navigation changes
+
+## Solution Implementation
+
+### 1. Navigation Event Detection
+
+Added comprehensive event listeners to detect Gmail navigation changes:
+
+```javascript
+// In class_app.js - bindGmailNavigationEvents()
+- hashchange events (Gmail's primary navigation method)
+- popstate events (back/forward navigation)
+- Click events on Gmail navigation elements
+- History API changes (pushState/replaceState)
+- DOM mutation observations for content area changes
+```
+
+### 2. Force Redraw Mechanism
+
+Implemented a robust force redraw system:
+
+```javascript
+// In class_gmailView.js - forceRedraw()
+- Clears existing button and popup elements
+- Resets internal state
+- Triggers fresh detection
+- Coordinates with popup view redraw
+```
+
+### 3. Improved Button Detection
+
+Enhanced the button detection to be more reliable:
+
+```javascript
+// In class_popupView.js - handleForceRedraw()
+- Clears cached HTML
+- Resets initialization state
+- Forces complete recreation of button and popup
+```
+
+### 4. Debounced Navigation Handling
+
+Added debouncing to prevent excessive redraws:
+
+```javascript
+// Uses setTimeout with clearTimeout to debounce navigation events
+// Prevents multiple rapid redraws during navigation
+```
+
+## Key Features
+
+### Navigation Detection Methods
+
+1. **URL Hash Changes**: Detects when Gmail's URL hash changes (e.g., `#inbox` → `#starred`)
+2. **History API**: Monitors `pushState` and `replaceState` calls
+3. **Navigation Clicks**: Detects clicks on Gmail navigation elements using selectors
+4. **DOM Mutations**: Observes changes to Gmail's main content area
+5. **Back/Forward**: Handles browser back/forward navigation
+
+### Gmail Navigation Selectors
+
+The extension detects navigation by monitoring clicks on elements with:
+- `role="navigation"`
+- Gmail's navigation classes (`.bq9`, `.bqA`, etc.)
+- Tooltip attributes containing navigation labels
+- Aria-label attributes for accessibility
+
+### Redraw Process
+
+When navigation is detected:
+
+1. **Clear Existing Elements**: Remove any existing G2T button and popup
+2. **Reset State**: Clear cached data and reset internal state
+3. **Fresh Detection**: Trigger new toolbar detection
+4. **Recreate Button**: Create and attach new button to the updated toolbar
+5. **Reinitialize Popup**: Set up popup with fresh DOM references
+
+## Testing
+
+### Manual Testing
+
+1. Load Gmail with the extension
+2. Navigate between different views (Inbox, Starred, Sent, Drafts, etc.)
+3. Verify the G2T button appears and functions correctly in each view
+4. Test browser back/forward navigation
+5. Test rapid navigation between views
+
+### Automated Testing
+
+Use the test functions in `test/navigation_test.js`:
+
+```javascript
+// Check app initialization
+testAppInitialization()
+
+// Simulate navigation events
+testGmailNavigation()
+
+// Manually trigger navigation detection
+testManualNavigationDetection()
+```
+
+## Performance Considerations
+
+- **Debouncing**: Navigation events are debounced to prevent excessive redraws
+- **Selective Observation**: DOM mutations are filtered to only relevant changes
+- **Cleanup**: Observers and timeouts are properly cleaned up
+- **Efficient Detection**: Uses jQuery selectors for fast DOM queries
+
+## Browser Compatibility
+
+- **Chrome**: Full support for all navigation detection methods
+- **Firefox**: Compatible with existing Firefox implementation
+- **Edge**: Should work with Chromium-based Edge
+
+## Future Improvements
+
+1. **Gmail API Integration**: If Gmail provides official APIs for navigation events
+2. **Performance Optimization**: Further optimize detection frequency and methods
+3. **User Feedback**: Add visual feedback during navigation redraws
+4. **Error Handling**: Enhanced error handling for edge cases
+
+## Files Modified
+
+- `class_app.js`: Added navigation event detection and handling
+- `views/class_gmailView.js`: Added force redraw functionality
+- `views/class_popupview.js`: Added force redraw handling
+- `test/navigation_test.js`: Added testing utilities
+
+## Related Issues
+
+This fix addresses the reported issue where G2T "disappears" during Gmail navigation. The solution ensures the extension remains functional across all Gmail views and navigation patterns.

--- a/test/navigation_test.js
+++ b/test/navigation_test.js
@@ -1,0 +1,73 @@
+/**
+ * Test file for Gmail navigation detection
+ * This file can be used to test the navigation detection functionality
+ */
+
+// Test function to simulate Gmail navigation
+function testGmailNavigation() {
+  console.log('Testing Gmail navigation detection...');
+  
+  // Simulate hash change
+  const originalHash = window.location.hash;
+  window.location.hash = '#test-navigation';
+  
+  // Simulate popstate
+  window.dispatchEvent(new PopStateEvent('popstate'));
+  
+  // Simulate click on navigation element
+  const mockNavElement = document.createElement('div');
+  mockNavElement.setAttribute('data-tooltip', 'Inbox');
+  mockNavElement.setAttribute('role', 'navigation');
+  document.body.appendChild(mockNavElement);
+  
+  const clickEvent = new MouseEvent('click', {
+    bubbles: true,
+    cancelable: true,
+    view: window
+  });
+  
+  mockNavElement.dispatchEvent(clickEvent);
+  
+  // Clean up
+  document.body.removeChild(mockNavElement);
+  window.location.hash = originalHash;
+  
+  console.log('Navigation test completed');
+}
+
+// Test function to verify the app is properly initialized
+function testAppInitialization() {
+  console.log('Testing app initialization...');
+  
+  if (window.g2t_app) {
+    console.log('✓ G2T app is initialized');
+    console.log('✓ Gmail view:', window.g2t_app.gmailView);
+    console.log('✓ Popup view:', window.g2t_app.popupView);
+    console.log('✓ Navigation timeout:', window.g2t_app.navigationTimeout);
+    console.log('✓ Navigation observer:', window.g2t_app.navigationObserver);
+  } else {
+    console.log('✗ G2T app is not initialized');
+  }
+}
+
+// Test function to manually trigger navigation detection
+function testManualNavigationDetection() {
+  console.log('Testing manual navigation detection...');
+  
+  if (window.g2t_app && typeof window.g2t_app.handleGmailNavigation === 'function') {
+    window.g2t_app.handleGmailNavigation();
+    console.log('✓ Navigation detection triggered');
+  } else {
+    console.log('✗ Navigation detection not available');
+  }
+}
+
+// Export test functions for use in console
+window.testGmailNavigation = testGmailNavigation;
+window.testAppInitialization = testAppInitialization;
+window.testManualNavigationDetection = testManualNavigationDetection;
+
+console.log('Gmail navigation tests loaded. Use:');
+console.log('- testAppInitialization() to check app state');
+console.log('- testGmailNavigation() to simulate navigation');
+console.log('- testManualNavigationDetection() to trigger detection manually');


### PR DESCRIPTION
Add robust Gmail navigation detection and force redraw mechanism to prevent the G2T button from disappearing when users switch between Gmail views.

Previously, the G2T button would "disappear" when users navigated between Gmail views (e.g., Inbox to Starred) because Gmail dynamically updates its DOM, and the extension's periodic 2-second check was insufficient. This PR implements comprehensive event listeners for URL hash changes, popstate, navigation clicks, History API calls, and DOM mutations within Gmail's main content area. Upon detecting navigation, the extension now forces a complete redraw and re-initialization of the G2T button, ensuring its persistence across view changes. The old periodic timer has been commented out as it should no longer be needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved detection of Gmail navigation events to keep the extension's button and popup visible and functional across Gmail views.
  * Added forced redraw capabilities for the toolbar button and popup to handle Gmail's dynamic interface updates.

* **Bug Fixes**
  * Resolved the issue causing the extension's button to disappear during Gmail navigation.

* **Documentation**
  * Added comprehensive documentation detailing the navigation fix and testing methods.

* **Tests**
  * Added test utilities for simulating Gmail navigation and validating extension behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->