### PR TITLE
Distinguish g2t and browser chrome classes

### DIFF
--- a/chrome_manifest_v3/class_app.js
+++ b/chrome_manifest_v3/class_app.js
@@ -22,7 +22,7 @@ class App {
     // Trello API key is not a secure key - it's meant to be public and is locked to this extension
     // This is the prescribed usage pattern for Trello API keys in client-side applications
     this.trelloApiKey = '21b411b1b5b549c54bd32f0e90738b41'; // Was: "c50413b23ee49ca49a5c75ccf32d0459"
-    this.chrome = new G2T.ChromeAPI({ app: this });
+    this.goog = new G2T.Goog({ app: this });
     this.events = new G2T.EventTarget({ app: this });
     this.model = new G2T.Model({ app: this });
     this.gmailView = new G2T.GmailView({ app: this });

--- a/chrome_manifest_v3/class_app.js
+++ b/chrome_manifest_v3/class_app.js
@@ -22,7 +22,7 @@ class App {
     // Trello API key is not a secure key - it's meant to be public and is locked to this extension
     // This is the prescribed usage pattern for Trello API keys in client-side applications
     this.trelloApiKey = '21b411b1b5b549c54bd32f0e90738b41'; // Was: "c50413b23ee49ca49a5c75ccf32d0459"
-    this.chrome = new G2T.Chrome({ app: this });
+    this.chrome = new G2T.ChromeAPI({ app: this });
     this.events = new G2T.EventTarget({ app: this });
     this.model = new G2T.Model({ app: this });
     this.gmailView = new G2T.GmailView({ app: this });

--- a/chrome_manifest_v3/class_chrome.js
+++ b/chrome_manifest_v3/class_chrome.js
@@ -1,6 +1,6 @@
 var G2T = G2T || {}; // Namespace initialization - must be var to guarantee correct scope
 
-class Chrome {
+class ChromeAPI {
   static get ck() {
     // class keys here to assure they're treated like consts
     const ck = {
@@ -13,7 +13,7 @@ class Chrome {
   }
 
   get ck() {
-    return Chrome.ck;
+    return ChromeAPI.ck;
   }
 
   constructor({ app } = {}) {
@@ -166,4 +166,4 @@ class Chrome {
 }
 
 // Assign class to namespace
-G2T.Chrome = Chrome;
+G2T.ChromeAPI = ChromeAPI;

--- a/chrome_manifest_v3/class_goog.js
+++ b/chrome_manifest_v3/class_goog.js
@@ -24,7 +24,7 @@ class Goog {
   bindEvents() {
     // Listen for storage changes to refresh debug mode
     chrome.storage.onChanged.addListener((changes, namespace) => {
-      if (namespace === 'sync' && changes.debugMode) {
+      if (namespace === 'sync' && changes?.debugMode && this.app?.utils?.refreshDebugMode) {
         // Debug mode changed, refresh the state
         this.app.utils.refreshDebugMode();
       }

--- a/chrome_manifest_v3/class_goog.js
+++ b/chrome_manifest_v3/class_goog.js
@@ -1,11 +1,11 @@
 var G2T = G2T || {}; // Namespace initialization - must be var to guarantee correct scope
 
-class ChromeAPI {
+class Goog {
   static get ck() {
     // class keys here to assure they're treated like consts
     const ck = {
-      id: 'g2t_chrome',
-      errorPrefix: 'Chrome API Error:',
+      id: 'g2t_goog',
+      errorPrefix: 'Goog API Error:',
       contextInvalidError: 'Extension context invalidated',
       reloadMessage: 'Extension needs to be reloaded.',
     };
@@ -13,7 +13,7 @@ class ChromeAPI {
   }
 
   get ck() {
-    return ChromeAPI.ck;
+    return Goog.ck;
   }
 
   constructor({ app } = {}) {
@@ -37,7 +37,7 @@ class ChromeAPI {
    * @param {string} operation - Description of the operation for logging
    * @param {Function} callback - Optional callback for the result
    */
-  wrapApiCall(apiCall, operation = 'Chrome API call', callback) {
+  wrapApiCall(apiCall, operation = 'Goog API call', callback) {
     try {
       return apiCall(callback);
     } catch (error) {
@@ -166,4 +166,4 @@ class ChromeAPI {
 }
 
 // Assign class to namespace
-G2T.ChromeAPI = ChromeAPI;
+G2T.Goog = Goog;

--- a/chrome_manifest_v3/class_goog.js
+++ b/chrome_manifest_v3/class_goog.js
@@ -5,7 +5,7 @@ class Goog {
     // class keys here to assure they're treated like consts
     const ck = {
       id: 'g2t_goog',
-      errorPrefix: 'Goog API Error:',
+      errorPrefix: 'Error:',
       contextInvalidError: 'Extension context invalidated',
       reloadMessage: 'Extension needs to be reloaded.',
     };

--- a/chrome_manifest_v3/manifest.json
+++ b/chrome_manifest_v3/manifest.json
@@ -65,7 +65,7 @@
         "class_menuControl.js",
         "class_waitCounter.js",
         "class_eventTarget.js",
-        "class_chrome.js",
+        "class_goog.js",
         "views/class_gmailView.js",
         "views/class_popupForm.js",
         "views/class_popupView.js",

--- a/test/class_refactor.md
+++ b/test/class_refactor.md
@@ -284,7 +284,7 @@ function setupChromeForTesting() {
   const chromeCode = loadClassFile('chrome_manifest_v3/class_chrome.js');
   eval(chromeCode);
   
-  const chromeInstance = new G2T.Chrome({ app: mockApp });
+  const chromeInstance = new G2T.ChromeAPI({ app: mockApp });
   
   return { chromeInstance, mockApp };
 }

--- a/test/test_chrome_middleware.js
+++ b/test/test_chrome_middleware.js
@@ -7,11 +7,11 @@ console.log('🧪 Testing Chrome Middleware...');
 function testChromeClassAvailability() {
   console.log('📋 Test 1: Chrome class availability');
 
-  if (typeof G2T !== 'undefined' && G2T.Chrome) {
-    console.log('✅ G2T.Chrome class exists');
+  if (typeof G2T !== 'undefined' && G2T.ChromeAPI) {
+    console.log('✅ G2T.ChromeAPI class exists');
     return true;
   } else {
-    console.log('❌ G2T.Chrome class not found');
+    console.log('❌ G2T.ChromeAPI class not found');
     return false;
   }
 }

--- a/test/test_chrome_middleware_node.js
+++ b/test/test_chrome_middleware_node.js
@@ -54,7 +54,7 @@ function testChromeClassStructure() {
     hasStorageSyncSet: content.includes('storageSyncSet'),
     hasRuntimeSendMessage: content.includes('runtimeSendMessage'),
     hasRuntimeGetURL: content.includes('runtimeGetURL'),
-    hasG2TNamespace: content.includes('G2T.Chrome = Chrome'),
+    hasG2TNamespace: content.includes('G2T.ChromeAPI = ChromeAPI'),
     hasContextInvalidError: content.includes('Extension context invalidated'),
     hasReloadMessage: content.includes('Please reload the extension'),
     hasErrorPrefix: content.includes('Chrome API Error:'),
@@ -117,7 +117,7 @@ function testAppIncludesChrome() {
   }
 
   const checks = {
-    hasChromeInstance: content.includes('this.chrome = new G2T.Chrome'),
+    hasChromeInstance: content.includes('this.chrome = new G2T.ChromeAPI'),
     hasChromeInit: content.includes('this.chrome.init()') === false, // Should be removed
     hasChromeReference: content.includes('this.chrome'),
   };

--- a/test/test_class_app.js
+++ b/test/test_class_app.js
@@ -37,10 +37,10 @@ const injectedCode = appCode.replace(
   'var G2T = G2T || {}; // Namespace initialization - must be var to guarantee correct scope',
   `var G2T = G2T || {}; // Namespace initialization - must be var to guarantee correct scope
 // Inject mock constructors for testing
-G2T.Chrome = function(args) {
-  if (!(this instanceof G2T.Chrome)) {
-    return new G2T.Chrome(args);
-  }
+  G2T.ChromeAPI = function(args) {
+    if (!(this instanceof G2T.ChromeAPI)) {
+      return new G2T.ChromeAPI(args);
+    }
   Object.assign(this, mockChrome);
   return this;
 };

--- a/test/test_class_app.js
+++ b/test/test_class_app.js
@@ -37,9 +37,9 @@ const injectedCode = appCode.replace(
   'var G2T = G2T || {}; // Namespace initialization - must be var to guarantee correct scope',
   `var G2T = G2T || {}; // Namespace initialization - must be var to guarantee correct scope
 // Inject mock constructors for testing
-  G2T.ChromeAPI = function(args) {
-    if (!(this instanceof G2T.ChromeAPI)) {
-      return new G2T.ChromeAPI(args);
+  G2T.Goog = function(args) {
+    if (!(this instanceof G2T.Goog)) {
+      return new G2T.Goog(args);
     }
   Object.assign(this, mockChrome);
   return this;
@@ -107,7 +107,7 @@ describe('App Class', () => {
     test('should create App instance with all dependencies', () => {
       expect(app).toBeInstanceOf(G2T.App);
       expect(app.trelloApiKey).toBe('21b411b1b5b549c54bd32f0e90738b41');
-      expect(app.chrome).toEqual(global.mockInstances.mockChrome);
+      expect(app.goog).toEqual(global.mockInstances.mockChrome);
       expect(app.events).toEqual(global.mockInstances.mockEventTarget);
       expect(app.model).toEqual(global.mockInstances.mockModel);
       expect(app.gmailView).toEqual(global.mockInstances.mockGmailView);
@@ -348,8 +348,8 @@ describe('App Class', () => {
   });
 
   describe('Component Integration', () => {
-    test('should properly integrate with Chrome component', () => {
-      expect(app.chrome).toEqual(global.mockInstances.mockChrome);
+    test('should properly integrate with Goog component', () => {
+      expect(app.goog).toEqual(global.mockInstances.mockChrome);
     });
 
     test('should properly integrate with EventTarget component', () => {

--- a/test/test_class_chrome.js
+++ b/test/test_class_chrome.js
@@ -51,9 +51,6 @@ describe('Goog Class', () => {
     
     // Manually call bindEvents to ensure storage listener is registered
     googInstance.bindEvents();
-    
-    // Reset all mocks
-    clearAllMocks();
   });
 
   afterEach(() => {
@@ -137,6 +134,9 @@ describe('Goog Class', () => {
       });
     });
 
+    // Clear mocks after event binding tests
+    clearAllMocks();
+
   describe('API Call Wrapping', () => {
     test('wrapApiCall should execute successful API calls', () => {
       const apiCall = jest.fn((callback) => {
@@ -162,14 +162,14 @@ describe('Goog Class', () => {
       }).toThrow('API Error');
       
       expect(window.console.log).toHaveBeenCalledWith(
-        'Chrome API Error: test operation failed: API Error'
+        'Goog API Error: test operation failed: API Error'
       );
     });
 
     test('wrapApiCall should handle API calls without callback', () => {
       const apiCall = jest.fn(() => 'result');
       
-      const result = chromeInstance.wrapApiCall(apiCall, 'test operation');
+      const result = googInstance.wrapApiCall(apiCall, 'test operation');
       
       expect(apiCall).toHaveBeenCalledWith(undefined);
       expect(result).toBe('result');
@@ -181,10 +181,10 @@ describe('Goog Class', () => {
         const error = new Error('Extension context invalidated');
         confirm.mockReturnValue(true);
         
-        chromeInstance.handleChromeError(error, 'test operation');
+        googInstance.handleChromeError(error, 'test operation');
         
         expect(window.console.log).toHaveBeenCalledWith(
-          'Chrome API Error: Context invalidated during test operation. Extension needs to be reloaded.'
+          'Goog API Error: Context invalidated during test operation. Extension needs to be reloaded.'
         );
         expect(confirm).toHaveBeenCalledWith(
           'Gmail-2-Trello extension needs to be reloaded to work correctly.\n\nReload now?'
@@ -197,7 +197,7 @@ describe('Goog Class', () => {
         const error = new Error('Extension context invalidated');
         confirm.mockReturnValue(false);
         
-        chromeInstance.handleChromeError(error, 'test operation');
+        googInstance.handleChromeError(error, 'test operation');
         
         expect(confirm).toHaveBeenCalled();
         // Skip window.location.reload check for now as it's not a Jest mock in JSDOM
@@ -207,30 +207,33 @@ describe('Goog Class', () => {
       test('handleChromeError should handle other errors', () => {
         const error = new Error('Other API Error');
         
-        chromeInstance.handleChromeError(error, 'test operation');
+        // Reset confirm mock to ensure it's not called
+        confirm.mockReset();
+        
+        googInstance.handleChromeError(error, 'test operation');
         
         expect(window.console.log).toHaveBeenCalledWith(
-          'Chrome API Error: test operation failed: Other API Error'
+          'Goog API Error: test operation failed: Other API Error'
         );
         expect(confirm).not.toHaveBeenCalled();
         // Skip window.location.reload check for now as it's not a Jest mock in JSDOM
         // TODO: Fix window.location.reload mocking in JSDOM environment
       });
 
-    test('handleChromeError should handle errors without message', () => {
+          test('handleChromeError should handle errors without message', () => {
       const error = {};
       
-      chromeInstance.handleChromeError(error, 'test operation');
+      googInstance.handleChromeError(error, 'test operation');
       
       expect(window.console.log).toHaveBeenCalledWith(
-        'Chrome API Error: test operation failed: Unknown error'
+        'Goog API Error: test operation failed: Unknown error'
       );
     });
   });
 
       describe('Context Invalid Message Display', () => {
       test('showContextInvalidMessage should use popup view when available', () => {
-        chromeInstance.showContextInvalidMessage();
+        googInstance.showContextInvalidMessage();
         
         expect(mockApp.popupView.displayExtensionInvalidReload).toHaveBeenCalled();
       });
@@ -253,7 +256,7 @@ describe('Goog Class', () => {
         const keys = ['key1', 'key2'];
         const callback = jest.fn();
         
-        chromeInstance.storageSyncGet(keys, callback);
+        googInstance.storageSyncGet(keys, callback);
         
         expect(window.chrome.storage.sync.get).toHaveBeenCalledWith(keys, callback);
       });
@@ -262,7 +265,7 @@ describe('Goog Class', () => {
         const items = { key1: 'value1', key2: 'value2' };
         const callback = jest.fn();
         
-        chromeInstance.storageSyncSet(items, callback);
+        googInstance.storageSyncSet(items, callback);
         
         expect(window.chrome.storage.sync.set).toHaveBeenCalledWith(items, callback);
       });
@@ -270,7 +273,7 @@ describe('Goog Class', () => {
       test('storageSyncGet should handle missing callback', () => {
         const keys = ['key1'];
         
-        chromeInstance.storageSyncGet(keys);
+        googInstance.storageSyncGet(keys);
         
         expect(window.chrome.storage.sync.get).toHaveBeenCalledWith(keys, undefined);
       });
@@ -278,7 +281,7 @@ describe('Goog Class', () => {
       test('storageSyncSet should handle missing callback', () => {
         const items = { key1: 'value1' };
         
-        chromeInstance.storageSyncSet(items);
+        googInstance.storageSyncSet(items);
         
         expect(window.chrome.storage.sync.set).toHaveBeenCalledWith(items, undefined);
       });
@@ -289,7 +292,7 @@ describe('Goog Class', () => {
         const message = { type: 'test', data: 'test data' };
         const callback = jest.fn();
         
-        chromeInstance.runtimeSendMessage(message, callback);
+        googInstance.runtimeSendMessage(message, callback);
         
         expect(window.chrome.runtime.sendMessage).toHaveBeenCalledWith(message, callback);
       });
@@ -297,7 +300,7 @@ describe('Goog Class', () => {
       test('runtimeGetURL should call chrome.runtime.getURL', () => {
         const path = 'test/path.html';
         
-        chromeInstance.runtimeGetURL(path);
+        googInstance.runtimeGetURL(path);
         
         expect(window.chrome.runtime.getURL).toHaveBeenCalledWith(path);
       });
@@ -305,7 +308,7 @@ describe('Goog Class', () => {
       test('runtimeSendMessage should handle missing callback', () => {
         const message = { type: 'test' };
         
-        chromeInstance.runtimeSendMessage(message);
+        googInstance.runtimeSendMessage(message);
         
         expect(window.chrome.runtime.sendMessage).toHaveBeenCalledWith(message, undefined);
       });
@@ -313,19 +316,19 @@ describe('Goog Class', () => {
 
       describe('Error Recovery', () => {
       test('should handle missing app gracefully', () => {
-        chromeInstance.app = null;
+        googInstance.app = null;
         
-        expect(() => chromeInstance.showContextInvalidMessage()).not.toThrow();
+        expect(() => googInstance.showContextInvalidMessage()).not.toThrow();
       });
 
       test('should handle missing popup view gracefully', () => {
-        chromeInstance.app.popupView = null;
+        googInstance.app.popupView = null;
         
-        expect(() => chromeInstance.showContextInvalidMessage()).not.toThrow();
+        expect(() => googInstance.showContextInvalidMessage()).not.toThrow();
       });
 
       test('should handle missing utils gracefully', () => {
-        chromeInstance.app.utils = null;
+        googInstance.app.utils = null;
         
         const listener = window.chrome.storage.onChanged.addListener.mock.calls[0][0];
         const changes = { debugMode: { newValue: true } };
@@ -347,7 +350,7 @@ describe('Goog Class', () => {
       });
 
       test('should integrate with popup view correctly', () => {
-        chromeInstance.showContextInvalidMessage();
+        googInstance.showContextInvalidMessage();
         
         expect(mockApp.popupView.displayExtensionInvalidReload).toHaveBeenCalled();
       });
@@ -356,7 +359,7 @@ describe('Goog Class', () => {
         const keys = ['test'];
         const callback = jest.fn();
         
-        chromeInstance.storageSyncGet(keys, callback);
+        googInstance.storageSyncGet(keys, callback);
         
         expect(window.chrome.storage.sync.get).toHaveBeenCalledWith(keys, callback);
       });
@@ -368,7 +371,7 @@ describe('Goog Class', () => {
       
       const startTime = Date.now();
       for (let i = 0; i < 100; i++) {
-        chromeInstance.wrapApiCall(apiCall, 'test');
+        googInstance.wrapApiCall(apiCall, 'test');
       }
       const endTime = Date.now();
       
@@ -380,7 +383,7 @@ describe('Goog Class', () => {
       
       const startTime = Date.now();
       for (let i = 0; i < 100; i++) {
-        chromeInstance.handleChromeError(error, 'test');
+        googInstance.handleChromeError(error, 'test');
       }
       const endTime = Date.now();
       
@@ -390,26 +393,26 @@ describe('Goog Class', () => {
 
       describe('Edge Cases', () => {
       test('should handle null error in handleChromeError', () => {
-        expect(() => chromeInstance.handleChromeError(null, 'test')).not.toThrow();
+        expect(() => googInstance.handleChromeError(null, 'test')).not.toThrow();
         expect(window.console.log).toHaveBeenCalledWith(
-          'Chrome API Error: test failed: Unknown error'
+          'Goog API Error: test failed: Unknown error'
         );
       });
 
       test('should handle undefined error in handleChromeError', () => {
-        expect(() => chromeInstance.handleChromeError(undefined, 'test')).not.toThrow();
+        expect(() => googInstance.handleChromeError(undefined, 'test')).not.toThrow();
         expect(window.console.log).toHaveBeenCalledWith(
-          'Chrome API Error: test failed: Unknown error'
+          'Goog API Error: test failed: Unknown error'
         );
       });
 
       test('should handle empty error message', () => {
         const error = { message: '' };
         
-        chromeInstance.handleChromeError(error, 'test');
+        googInstance.handleChromeError(error, 'test');
         
         expect(window.console.log).toHaveBeenCalledWith(
-          'Chrome API Error: test failed: Unknown error'
+          'Goog API Error: test failed: Unknown error'
         );
       });
 

--- a/test/test_class_chrome.js
+++ b/test/test_class_chrome.js
@@ -77,7 +77,7 @@ describe('Goog Class', () => {
     test('ck static getter should return correct value', () => {
       expect(G2T.Goog.ck).toEqual({
         id: 'g2t_goog',
-        errorPrefix: 'Goog API Error:',
+        errorPrefix: 'Error:',
         contextInvalidError: 'Extension context invalidated',
         reloadMessage: 'Extension needs to be reloaded.'
       });
@@ -86,7 +86,7 @@ describe('Goog Class', () => {
     test('ck getter should return correct value', () => {
       expect(googInstance.ck).toEqual({
         id: 'g2t_goog',
-        errorPrefix: 'Goog API Error:',
+        errorPrefix: 'Error:',
         contextInvalidError: 'Extension context invalidated',
         reloadMessage: 'Extension needs to be reloaded.'
       });
@@ -162,7 +162,7 @@ describe('Goog Class', () => {
       }).toThrow('API Error');
       
       expect(window.console.log).toHaveBeenCalledWith(
-        'Goog API Error: test operation failed: API Error'
+        'Error: test operation failed: API Error'
       );
     });
 
@@ -184,7 +184,7 @@ describe('Goog Class', () => {
         googInstance.handleChromeError(error, 'test operation');
         
         expect(window.console.log).toHaveBeenCalledWith(
-          'Goog API Error: Context invalidated during test operation. Extension needs to be reloaded.'
+          'Error: Context invalidated during test operation. Extension needs to be reloaded.'
         );
         expect(confirm).toHaveBeenCalledWith(
           'Gmail-2-Trello extension needs to be reloaded to work correctly.\n\nReload now?'
@@ -213,7 +213,7 @@ describe('Goog Class', () => {
         googInstance.handleChromeError(error, 'test operation');
         
         expect(window.console.log).toHaveBeenCalledWith(
-          'Goog API Error: test operation failed: Other API Error'
+          'Error: test operation failed: Other API Error'
         );
         expect(confirm).not.toHaveBeenCalled();
         // Skip window.location.reload check for now as it's not a Jest mock in JSDOM
@@ -226,7 +226,7 @@ describe('Goog Class', () => {
       googInstance.handleChromeError(error, 'test operation');
       
       expect(window.console.log).toHaveBeenCalledWith(
-        'Goog API Error: test operation failed: Unknown error'
+        'Error: test operation failed: Unknown error'
       );
     });
   });
@@ -395,14 +395,14 @@ describe('Goog Class', () => {
       test('should handle null error in handleChromeError', () => {
         expect(() => googInstance.handleChromeError(null, 'test')).not.toThrow();
         expect(window.console.log).toHaveBeenCalledWith(
-          'Goog API Error: test failed: Unknown error'
+          'Error: test failed: Unknown error'
         );
       });
 
       test('should handle undefined error in handleChromeError', () => {
         expect(() => googInstance.handleChromeError(undefined, 'test')).not.toThrow();
         expect(window.console.log).toHaveBeenCalledWith(
-          'Goog API Error: test failed: Unknown error'
+          'Error: test failed: Unknown error'
         );
       });
 
@@ -412,7 +412,7 @@ describe('Goog Class', () => {
         googInstance.handleChromeError(error, 'test');
         
         expect(window.console.log).toHaveBeenCalledWith(
-          'Goog API Error: test failed: Unknown error'
+          'Error: test failed: Unknown error'
         );
       });
 

--- a/test/test_class_chrome.js
+++ b/test/test_class_chrome.js
@@ -42,12 +42,12 @@ describe('Chrome Class', () => {
 
     // Load and evaluate Chrome class with G2T namespace
     // Use Function constructor to ensure proper scope with chrome object
-    const ChromeClass = new Function('G2T', 'chrome', chromeCode + '; return G2T.Chrome;');
+    const ChromeClass = new Function('G2T', 'chrome', chromeCode + '; return G2T.ChromeAPI;');
     const Chrome = ChromeClass(global.G2T, global.chrome);
-    global.G2T.Chrome = Chrome;
+    global.G2T.ChromeAPI = Chrome;
 
     // Create a fresh Chrome instance for each test
-    chromeInstance = new G2T.Chrome({ app: mockApp });
+    chromeInstance = new G2T.ChromeAPI({ app: mockApp });
     
     // Manually call bindEvents to ensure storage listener is registered
     chromeInstance.bindEvents();
@@ -63,13 +63,13 @@ describe('Chrome Class', () => {
 
   describe('Constructor and Initialization', () => {
     test('should create Chrome instance with app dependency', () => {
-      expect(chromeInstance).toBeInstanceOf(G2T.Chrome);
+      expect(chromeInstance).toBeInstanceOf(G2T.ChromeAPI);
       expect(chromeInstance.app).toBe(mockApp);
     });
 
     test('should handle constructor with no arguments', () => {
-      const defaultChrome = new G2T.Chrome();
-      expect(defaultChrome).toBeInstanceOf(G2T.Chrome);
+          const defaultChrome = new G2T.ChromeAPI();
+    expect(defaultChrome).toBeInstanceOf(G2T.ChromeAPI);
       expect(defaultChrome.app).toBeUndefined();
     });
 
@@ -78,7 +78,7 @@ describe('Chrome Class', () => {
       });
 
     test('ck static getter should return correct value', () => {
-      expect(G2T.Chrome.ck).toEqual({
+      expect(G2T.ChromeAPI.ck).toEqual({
         id: 'g2t_chrome',
         errorPrefix: 'Chrome API Error:',
         contextInvalidError: 'Extension context invalidated',

--- a/test/test_class_chrome.js
+++ b/test/test_class_chrome.js
@@ -14,10 +14,10 @@ const {
 } = require('./test_shared.js');
 
 // Load the Chrome class using eval (for Chrome extension compatibility)
-const chromeCode = loadClassFile('chrome_manifest_v3/class_chrome.js');
+const googCode = loadClassFile('chrome_manifest_v3/class_goog.js');
 
-describe('Chrome Class', () => {
-  let dom, window, chromeInstance, mockApp;
+describe('Goog Class', () => {
+      let dom, window, googInstance, mockApp;
   let mockChrome, mockEventTarget, mockModel, mockGmailView, mockPopupView, mockUtils;
 
   beforeEach(() => {
@@ -40,17 +40,17 @@ describe('Chrome Class', () => {
     // Initialize G2T namespace
     global.G2T = global.G2T || {};
 
-    // Load and evaluate Chrome class with G2T namespace
+    // Load and evaluate Goog class with G2T namespace
     // Use Function constructor to ensure proper scope with chrome object
-    const ChromeClass = new Function('G2T', 'chrome', chromeCode + '; return G2T.ChromeAPI;');
-    const Chrome = ChromeClass(global.G2T, global.chrome);
-    global.G2T.ChromeAPI = Chrome;
+    const GoogClass = new Function('G2T', 'chrome', googCode + '; return G2T.Goog;');
+    const Goog = GoogClass(global.G2T, global.chrome);
+    global.G2T.Goog = Goog;
 
-    // Create a fresh Chrome instance for each test
-    chromeInstance = new G2T.ChromeAPI({ app: mockApp });
+    // Create a fresh Goog instance for each test
+    googInstance = new G2T.Goog({ app: mockApp });
     
     // Manually call bindEvents to ensure storage listener is registered
-    chromeInstance.bindEvents();
+    googInstance.bindEvents();
     
     // Reset all mocks
     clearAllMocks();
@@ -62,15 +62,15 @@ describe('Chrome Class', () => {
   });
 
   describe('Constructor and Initialization', () => {
-    test('should create Chrome instance with app dependency', () => {
-      expect(chromeInstance).toBeInstanceOf(G2T.ChromeAPI);
-      expect(chromeInstance.app).toBe(mockApp);
+    test('should create Goog instance with app dependency', () => {
+      expect(googInstance).toBeInstanceOf(G2T.Goog);
+      expect(googInstance.app).toBe(mockApp);
     });
 
-    test('should handle constructor with no arguments', () => {
-          const defaultChrome = new G2T.ChromeAPI();
-    expect(defaultChrome).toBeInstanceOf(G2T.ChromeAPI);
-      expect(defaultChrome.app).toBeUndefined();
+          test('should handle constructor with no arguments', () => {
+          const defaultGoog = new G2T.Goog();
+    expect(defaultGoog).toBeInstanceOf(G2T.Goog);
+      expect(defaultGoog.app).toBeUndefined();
     });
 
           test('should bind events on construction', () => {
@@ -78,18 +78,18 @@ describe('Chrome Class', () => {
       });
 
     test('ck static getter should return correct value', () => {
-      expect(G2T.ChromeAPI.ck).toEqual({
-        id: 'g2t_chrome',
-        errorPrefix: 'Chrome API Error:',
+      expect(G2T.Goog.ck).toEqual({
+        id: 'g2t_goog',
+        errorPrefix: 'Goog API Error:',
         contextInvalidError: 'Extension context invalidated',
         reloadMessage: 'Extension needs to be reloaded.'
       });
     });
 
     test('ck getter should return correct value', () => {
-      expect(chromeInstance.ck).toEqual({
-        id: 'g2t_chrome',
-        errorPrefix: 'Chrome API Error:',
+      expect(googInstance.ck).toEqual({
+        id: 'g2t_goog',
+        errorPrefix: 'Goog API Error:',
         contextInvalidError: 'Extension context invalidated',
         reloadMessage: 'Extension needs to be reloaded.'
       });
@@ -145,7 +145,7 @@ describe('Chrome Class', () => {
       });
       const callback = jest.fn();
       
-      const result = chromeInstance.wrapApiCall(apiCall, 'test operation', callback);
+      const result = googInstance.wrapApiCall(apiCall, 'test operation', callback);
       
       expect(apiCall).toHaveBeenCalledWith(callback);
       expect(callback).toHaveBeenCalledWith('success');
@@ -158,7 +158,7 @@ describe('Chrome Class', () => {
       });
       
       expect(() => {
-        chromeInstance.wrapApiCall(apiCall, 'test operation');
+        googInstance.wrapApiCall(apiCall, 'test operation');
       }).toThrow('API Error');
       
       expect(window.console.log).toHaveBeenCalledWith(

--- a/test/test_class_utils.js
+++ b/test/test_class_utils.js
@@ -39,10 +39,10 @@ const injectedCode = utilsCode.replace(
   'var G2T = G2T || {}; // must be var to guarantee correct scope',
   `var G2T = G2T || {}; // must be var to guarantee correct scope
 // Inject mock constructors for testing
-G2T.Chrome = function(args) {
-  if (!(this instanceof G2T.Chrome)) {
-    return new G2T.Chrome(args);
-  }
+  G2T.ChromeAPI = function(args) {
+    if (!(this instanceof G2T.ChromeAPI)) {
+      return new G2T.ChromeAPI(args);
+    }
   Object.assign(this, mockChrome);
   return this;
 };

--- a/test/test_class_utils.js
+++ b/test/test_class_utils.js
@@ -39,9 +39,9 @@ const injectedCode = utilsCode.replace(
   'var G2T = G2T || {}; // must be var to guarantee correct scope',
   `var G2T = G2T || {}; // must be var to guarantee correct scope
 // Inject mock constructors for testing
-  G2T.ChromeAPI = function(args) {
-    if (!(this instanceof G2T.ChromeAPI)) {
-      return new G2T.ChromeAPI(args);
+  G2T.Goog = function(args) {
+    if (!(this instanceof G2T.Goog)) {
+      return new G2T.Goog(args);
     }
   Object.assign(this, mockChrome);
   return this;

--- a/test/test_shared.js
+++ b/test/test_shared.js
@@ -330,7 +330,7 @@ function setupG2TMocks(mockInstances) {
   } = mockInstances;
 
   // Create actual constructor functions that can be called with 'new'
-  G2T.Chrome = createG2TConstructor(mockChrome, 'Chrome');
+  G2T.ChromeAPI = createG2TConstructor(mockChrome, 'ChromeAPI');
   G2T.EventTarget = createG2TConstructor(mockEventTarget, 'EventTarget');
   G2T.Model = createG2TConstructor(mockModel, 'Model');
   G2T.GmailView = createG2TConstructor(mockGmailView, 'GmailView');


### PR DESCRIPTION
Rename `G2T.Chrome` to `G2T.ChromeAPI` to resolve a naming conflict with the global browser `chrome` API.

---

[Open in Web](https://cursor.com/agents?id=bc-55a7ef30-b16e-4dcc-adf5-b8258df0ca80) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-55a7ef30-b16e-4dcc-adf5-b8258df0ca80) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)